### PR TITLE
Add bilingual language toggle and dynamic idea hub grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
-trial
+# Idea Hub playground
+
+This repository hosts a lightweight static site that collects quick links for experiments (games, dashboards, and AI research snapshots).
+
+## Resolving GitHub merge conflicts
+
+If a pull request shows the "This branch has conflicts" warning (like in the screenshot), pull the latest changes from the main branch and merge or rebase them locally before pushing again.
+
+1. Make sure you have the upstream remote configured:
+   ```bash
+   git remote add origin <your-repo-url> # skip if already set
+   git fetch origin
+   ```
+2. Update the base branch and rebase your feature branch:
+   ```bash
+   git checkout main
+   git pull origin main
+   git checkout work
+   git rebase main
+   ```
+3. Fix the files that show conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`), then stage the fixes:
+   ```bash
+   # edit the conflicting files to keep the correct content
+   git add index.html top-ai-llm-stars.html
+   ```
+4. Continue the rebase and push the updated branch:
+   ```bash
+   git rebase --continue
+   git push --force-with-lease origin work
+   ```
+
+If you prefer merging instead of rebasing, replace steps 2–4 with `git merge main` and a regular `git push`. After the updated branch is on GitHub, the pull request will show as conflict-free.

--- a/index.html
+++ b/index.html
@@ -301,7 +301,7 @@
             'Every card on this page is driven by a single JavaScript array. Editing that list is all you need to keep the hub growing.',
           howToSteps: [
             'Duplicate one of the objects in the ideas array.',
-            'Update the link, icon, and localized copy for English and zh-HK.',
+            'Update the link, icon, and localized copy for English and zh-HK (missing translations fall back to English).',
             'Save the file—your new tile appears automatically.',
           ],
         },
@@ -315,7 +315,7 @@
           howToIntro: '此頁的所有卡片都來自同一個 JavaScript 陣列，更新它就能持續擴充內容。',
           howToSteps: [
             '複製 ideas 陣列中的其中一個物件。',
-            '更新連結、圖示，以及英文與繁體中文（香港）的對應文案。',
+            '更新連結、圖示，以及英文與繁體中文（香港）的對應文案（如未填寫繁中會自動顯示英文）。',
             '儲存檔案後，新卡片便會自動出現。',
           ],
         },
@@ -367,6 +367,27 @@
 
       let currentLocale = DEFAULT_LOCALE;
 
+      function getLocalizedCopy(copyMap, locale) {
+        if (!copyMap || typeof copyMap !== 'object') {
+          return { title: '', summary: '' };
+        }
+
+        const fromLocale = copyMap[locale];
+        if (fromLocale) {
+          return fromLocale;
+        }
+
+        return copyMap[DEFAULT_LOCALE] || { title: '', summary: '' };
+      }
+
+      function getLocalizedBadgeText(badge, locale) {
+        if (!badge || typeof badge !== 'object' || !badge.text) {
+          return '';
+        }
+
+        return badge.text[locale] || badge.text[DEFAULT_LOCALE] || '';
+      }
+
       function createCard(idea, locale) {
         const link = document.createElement('a');
         link.className = 'idea-card';
@@ -384,11 +405,16 @@
         const textWrapper = document.createElement('div');
         textWrapper.className = 'card-text';
 
+        const localizedCopy = getLocalizedCopy(idea.copy, locale);
+        if (localizedCopy.title) {
+          link.setAttribute('aria-label', localizedCopy.title);
+        }
+
         const title = document.createElement('h2');
-        title.textContent = idea.copy[locale].title;
+        title.textContent = localizedCopy.title;
 
         const summary = document.createElement('p');
-        summary.textContent = idea.copy[locale].summary;
+        summary.textContent = localizedCopy.summary;
 
         textWrapper.append(title, summary);
         header.append(icon, textWrapper);
@@ -400,7 +426,7 @@
 
           idea.badges.forEach((badge) => {
             const item = document.createElement('li');
-            item.textContent = badge.text[locale];
+            item.textContent = getLocalizedBadgeText(badge, locale);
             metaList.appendChild(item);
           });
 

--- a/index.html
+++ b/index.html
@@ -1,461 +1,413 @@
 <!DOCTYPE html>
-<html lang="zh-Hant">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>貪食蛇 Mini Game</title>
-  <style>
-    :root {
-      color-scheme: dark;
-      font-family: "Noto Sans TC", "Segoe UI", "Helvetica Neue", Arial, sans-serif;
-      --bg-dark: #0b1120;
-      --bg-panel: rgba(15, 23, 42, 0.78);
-      --accent: #38bdf8;
-      --accent-strong: #22d3ee;
-      --snake: #f59e0b;
-      --snake-head: #f97316;
-      --food: #22c55e;
-    }
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Idea Hub</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg-base: #070b16;
+        --bg-panel: rgba(15, 23, 42, 0.82);
+        --accent: #38bdf8;
+        --accent-strong: #22d3ee;
+        --text: #e2e8f0;
+        --text-soft: rgba(226, 232, 240, 0.72);
+        font-family: "Inter", "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+      }
 
-    * {
-      box-sizing: border-box;
-    }
+      * {
+        box-sizing: border-box;
+      }
 
-    body {
-      margin: 0;
-      min-height: 100vh;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      padding: clamp(16px, 4vw, 40px);
-      background:
-        radial-gradient(circle at 12% 18%, rgba(56, 189, 248, 0.22), transparent 60%),
-        radial-gradient(circle at 88% 12%, rgba(129, 140, 248, 0.18), transparent 62%),
-        linear-gradient(135deg, #020617 0%, #0f172a 60%, #1e293b 100%);
-      color: #f8fafc;
-    }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: clamp(20px, 5vw, 48px);
+        background:
+          radial-gradient(circle at 12% 18%, rgba(56, 189, 248, 0.22), transparent 60%),
+          radial-gradient(circle at 88% 12%, rgba(129, 140, 248, 0.16), transparent 62%),
+          linear-gradient(140deg, #020617 0%, #0f172a 60%, #1e293b 100%);
+        color: var(--text);
+      }
 
-    main {
-      width: min(420px, 100%);
-      background: var(--bg-panel);
-      border-radius: 28px;
-      border: 1px solid rgba(148, 163, 184, 0.25);
-      box-shadow: 0 28px 60px rgba(2, 6, 23, 0.45);
-      padding: clamp(20px, 5vw, 32px);
-      backdrop-filter: blur(14px);
-    }
-
-    h1 {
-      margin: 0;
-      font-size: clamp(1.8rem, 5.5vw, 2.4rem);
-      font-weight: 700;
-      letter-spacing: 0.04em;
-      text-align: center;
-    }
-
-    .subtitle {
-      margin: 8px 0 20px;
-      text-align: center;
-      font-size: 0.95rem;
-      color: rgba(226, 232, 240, 0.75);
-    }
-
-    .scoreboard {
-      display: flex;
-      justify-content: space-between;
-      gap: 16px;
-      align-items: center;
-      padding: 12px 16px;
-      border-radius: 16px;
-      background: rgba(15, 23, 42, 0.65);
-      border: 1px solid rgba(59, 130, 246, 0.2);
-      margin-bottom: 18px;
-      font-size: 0.95rem;
-    }
-
-    .scoreboard span {
-      font-weight: 600;
-      font-size: 1.1rem;
-      color: var(--accent);
-    }
-
-    canvas {
-      display: block;
-      width: min(90vw, 360px);
-      max-width: 100%;
-      height: auto;
-      margin: 0 auto;
-      border-radius: 18px;
-      border: 1px solid rgba(148, 163, 184, 0.2);
-      background: radial-gradient(circle at 20% 20%, rgba(148, 163, 184, 0.06), transparent 70%),
-                  radial-gradient(circle at 80% 80%, rgba(148, 163, 184, 0.04), transparent 75%),
-                  #0f172a;
-      image-rendering: pixelated;
-    }
-
-    .controls {
-      display: flex;
-      justify-content: center;
-      gap: 12px;
-      margin: 18px 0;
-      flex-wrap: wrap;
-    }
-
-    button {
-      appearance: none;
-      border: none;
-      border-radius: 999px;
-      padding: 10px 18px;
-      font-size: 0.95rem;
-      font-weight: 600;
-      cursor: pointer;
-      color: #0b1120;
-      background: linear-gradient(135deg, var(--accent), var(--accent-strong));
-      transition: transform 0.12s ease, box-shadow 0.12s ease;
-      box-shadow: 0 12px 20px rgba(34, 211, 238, 0.28);
-      touch-action: manipulation;
-    }
-
-    button.secondary {
-      background: rgba(148, 163, 184, 0.2);
-      color: #e2e8f0;
-      box-shadow: none;
-      border: 1px solid rgba(148, 163, 184, 0.35);
-    }
-
-    button:focus-visible {
-      outline: 3px solid rgba(34, 211, 238, 0.6);
-      outline-offset: 2px;
-    }
-
-    button:hover {
-      transform: translateY(-1px);
-    }
-
-    .status {
-      text-align: center;
-      font-size: 0.9rem;
-      color: rgba(226, 232, 240, 0.75);
-      min-height: 1.6em;
-    }
-
-    .instructions {
-      margin: 20px 0 0;
-      padding: 16px;
-      border-radius: 16px;
-      background: rgba(15, 23, 42, 0.6);
-      border: 1px solid rgba(59, 130, 246, 0.18);
-      font-size: 0.85rem;
-      line-height: 1.6;
-      color: rgba(226, 232, 240, 0.75);
-    }
-
-    .touch-controls {
-      margin-top: 12px;
-      display: grid;
-      grid-template-columns: repeat(3, 48px);
-      justify-content: center;
-      gap: 8px;
-      user-select: none;
-    }
-
-    .touch-controls button {
-      width: 48px;
-      height: 48px;
-      border-radius: 12px;
-      font-size: 1.1rem;
-      padding: 0;
-      box-shadow: none;
-      background: rgba(56, 189, 248, 0.22);
-      color: var(--accent-strong);
-      border: 1px solid rgba(56, 189, 248, 0.35);
-    }
-
-    .touch-controls button:active {
-      transform: scale(0.96);
-    }
-
-    @media (max-width: 420px) {
       main {
+        width: min(960px, 100%);
+        background: var(--bg-panel);
+        border-radius: 28px;
+        border: 1px solid rgba(148, 163, 184, 0.22);
+        box-shadow: 0 28px 60px rgba(2, 6, 23, 0.45);
+        padding: clamp(24px, 4vw, 42px);
+        backdrop-filter: blur(16px);
+        position: relative;
+      }
+
+      header {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        margin-bottom: clamp(24px, 5vw, 40px);
+        text-align: center;
+      }
+
+      h1 {
+        margin: 0;
+        font-size: clamp(2rem, 5vw, 2.75rem);
+        font-weight: 700;
+        letter-spacing: 0.01em;
+      }
+
+      .lead {
+        margin: 0 auto;
+        max-width: 580px;
+        font-size: clamp(1rem, 2.6vw, 1.08rem);
+        color: var(--text-soft);
+        line-height: 1.6;
+      }
+
+      .idea-grid {
+        display: grid;
+        gap: clamp(16px, 3vw, 24px);
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      }
+
+      .idea-card {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        padding: clamp(20px, 3vw, 26px);
         border-radius: 22px;
+        background: rgba(15, 23, 42, 0.72);
+        border: 1px solid rgba(148, 163, 184, 0.26);
+        text-decoration: none;
+        color: inherit;
+        transition: transform 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease;
       }
 
-      .scoreboard {
-        font-size: 0.9rem;
-      }
-    }
-  </style>
-</head>
-<body>
-  <main>
-    <h1>貪食蛇 Mini Game</h1>
-    <p class="subtitle">吃掉能量球、成為最長的蛇！用鍵盤或觸控方向鍵操作。</p>
-
-    <section class="scoreboard" aria-live="polite">
-      <div>分數：<span id="score">0</span></div>
-      <div>最佳紀錄：<span id="high-score">0</span></div>
-    </section>
-
-    <canvas id="game-board" width="360" height="360" role="img" aria-label="貪食蛇遊戲棋盤"></canvas>
-
-    <div class="controls">
-      <button id="start-button" type="button">開始遊戲</button>
-      <button id="reset-button" class="secondary" type="button">清除最佳紀錄</button>
-    </div>
-
-    <p id="status" class="status" aria-live="polite">準備好就按「開始遊戲」吧！</p>
-
-    <div class="touch-controls" aria-hidden="true">
-      <button type="button" data-direction="up" aria-label="向上">▲</button>
-      <span></span>
-      <button type="button" data-direction="right" aria-label="向右">▶</button>
-      <button type="button" data-direction="left" aria-label="向左">◀</button>
-      <span></span>
-      <button type="button" data-direction="down" aria-label="向下">▼</button>
-    </div>
-
-    <aside class="instructions">
-      <strong>玩法提示：</strong>
-      <ul>
-        <li>方向鍵或 <kbd>W</kbd><kbd>A</kbd><kbd>S</kbd><kbd>D</kbd> 控制蛇的移動。</li>
-        <li>吃到能量球會加分並讓蛇變長。</li>
-        <li>撞到牆壁或自己的身體就會遊戲結束。</li>
-        <li>最佳紀錄會儲存在瀏覽器的本機儲存中。</li>
-      </ul>
-    </aside>
-  </main>
-
-  <script>
-    (function () {
-      const canvas = document.getElementById('game-board');
-      const ctx = canvas.getContext('2d');
-      const scoreEl = document.getElementById('score');
-      const highScoreEl = document.getElementById('high-score');
-      const statusEl = document.getElementById('status');
-      const startButton = document.getElementById('start-button');
-      const resetButton = document.getElementById('reset-button');
-      const controlButtons = document.querySelectorAll('[data-direction]');
-
-      const tileSize = 20;
-      const tiles = canvas.width / tileSize;
-      const highScoreKey = 'snakeHighScore';
-
-      let snake = [];
-      let food = { x: 0, y: 0 };
-      let velocity = { x: 0, y: 0 };
-      let nextVelocity = { x: 0, y: 0 };
-      let score = 0;
-      let highScore = Number(localStorage.getItem(highScoreKey)) || 0;
-      let gameInterval = null;
-      let tickSpeed = 130;
-
-      highScoreEl.textContent = highScore;
-
-      function startGame(initialDirection) {
-        if (gameInterval) {
-          clearInterval(gameInterval);
-        }
-        resetGame(initialDirection);
-        statusEl.textContent = '遊戲開始，祝你好運！';
-        gameInterval = setInterval(step, tickSpeed);
+      .idea-card:hover,
+      .idea-card:focus-visible {
+        transform: translateY(-4px);
+        border-color: rgba(56, 189, 248, 0.52);
+        box-shadow: 0 18px 32px rgba(8, 47, 73, 0.4);
+        outline: none;
       }
 
-      function resetGame(initialDirection) {
-        snake = [{ x: Math.floor(tiles / 2), y: Math.floor(tiles / 2) }];
-        const direction = initialDirection ? { ...initialDirection } : { x: 1, y: 0 };
-        velocity = { x: 0, y: 0 };
-        nextVelocity = direction;
-        score = 0;
-        tickSpeed = 130;
-        updateScore();
-        placeFood();
-        render();
+      .card-header {
+        display: flex;
+        align-items: center;
+        gap: 12px;
       }
 
-      function updateScore() {
-        scoreEl.textContent = score;
-        highScoreEl.textContent = highScore;
+      .idea-icon {
+        flex-shrink: 0;
+        width: 42px;
+        height: 42px;
+        border-radius: 14px;
+        display: grid;
+        place-items: center;
+        font-size: 1.4rem;
+        background: rgba(56, 189, 248, 0.16);
+        border: 1px solid rgba(56, 189, 248, 0.35);
       }
 
-      function placeFood() {
-        let newFood;
-        do {
-          newFood = {
-            x: Math.floor(Math.random() * tiles),
-            y: Math.floor(Math.random() * tiles)
-          };
-        } while (snake.some(segment => segment.x === newFood.x && segment.y === newFood.y));
-        food = newFood;
+      .idea-card h2 {
+        margin: 0;
+        font-size: 1.18rem;
+        font-weight: 600;
       }
 
-      function step() {
-        if (!snake.length) {
-          return;
-        }
-        velocity = nextVelocity;
-        const head = { x: snake[0].x + velocity.x, y: snake[0].y + velocity.y };
+      .idea-card p {
+        margin: 0;
+        color: var(--text-soft);
+        line-height: 1.5;
+        font-size: 0.98rem;
+      }
 
-        if (velocity.x === 0 && velocity.y === 0) {
-          return;
-        }
+      .meta {
+        margin: 0;
+        padding: 0;
+        list-style: none;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        font-size: 0.78rem;
+        color: rgba(148, 163, 184, 0.8);
+      }
 
-        if (isCollision(head)) {
-          endGame();
-          return;
-        }
+      .meta span {
+        color: var(--accent);
+        font-weight: 600;
+      }
 
-        snake.unshift(head);
+      .meta li {
+        display: flex;
+        gap: 6px;
+        align-items: center;
+        background: rgba(15, 23, 42, 0.72);
+        border-radius: 999px;
+        padding: 6px 12px;
+        border: 1px solid rgba(148, 163, 184, 0.24);
+      }
 
-        if (head.x === food.x && head.y === food.y) {
-          score += 1;
-          if (score > highScore) {
-            highScore = score;
-            localStorage.setItem(highScoreKey, String(highScore));
-            statusEl.textContent = '太棒了！創下新紀錄！';
-          }
-          updateScore();
-          placeFood();
-          speedUp();
-        } else {
-          snake.pop();
+      .cta-note {
+        margin-top: clamp(24px, 4vw, 32px);
+        padding: clamp(18px, 3vw, 24px);
+        border-radius: 18px;
+        border: 1px dashed rgba(148, 163, 184, 0.35);
+        background: rgba(15, 23, 42, 0.6);
+        font-size: 0.92rem;
+        color: var(--text-soft);
+        line-height: 1.6;
+      }
+
+      .cta-note strong {
+        color: var(--text);
+        display: block;
+        margin-bottom: 6px;
+      }
+
+      .top-bar {
+        position: absolute;
+        top: clamp(16px, 3vw, 24px);
+        right: clamp(16px, 3vw, 24px);
+        display: flex;
+        justify-content: flex-end;
+      }
+
+      .lang-toggle {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 8px 14px;
+        border-radius: 999px;
+        border: 1px solid rgba(148, 163, 184, 0.3);
+        background: rgba(15, 23, 42, 0.7);
+        color: var(--text);
+        cursor: pointer;
+        font-size: 0.85rem;
+        font-weight: 600;
+        transition: border-color 0.18s ease, background 0.18s ease, color 0.18s ease;
+      }
+
+      .lang-toggle:hover,
+      .lang-toggle:focus-visible {
+        border-color: rgba(56, 189, 248, 0.6);
+        color: var(--accent-strong);
+        outline: none;
+      }
+
+      .lang-toggle span {
+        opacity: 0.6;
+        transition: opacity 0.18s ease;
+      }
+
+      .lang-toggle span[data-active="true"] {
+        opacity: 1;
+      }
+
+      @media (max-width: 600px) {
+        .idea-card {
+          padding: 18px;
         }
 
-        render();
-      }
-
-      function isCollision(position) {
-        const hitWall = position.x < 0 || position.y < 0 || position.x >= tiles || position.y >= tiles;
-        const hitSelf = snake.some(segment => segment.x === position.x && segment.y === position.y);
-        return hitWall || hitSelf;
-      }
-
-      function endGame() {
-        clearInterval(gameInterval);
-        gameInterval = null;
-        statusEl.textContent = `遊戲結束！本次得分：${score}。按「開始遊戲」再挑戰一次。`;
-      }
-
-      function speedUp() {
-        if (tickSpeed > 70 && score % 5 === 0) {
-          tickSpeed -= 5;
-          clearInterval(gameInterval);
-          gameInterval = setInterval(step, tickSpeed);
+        .top-bar {
+          position: static;
+          justify-content: center;
+          margin-bottom: 18px;
         }
       }
+    </style>
+  </head>
+  <body>
+    <main>
+      <div class="top-bar">
+        <button type="button" class="lang-toggle" data-lang-toggle aria-label="Switch language">
+          <span data-lang-code="en" data-active="true">EN</span> / <span data-lang-code="zh-HK">繁</span>
+        </button>
+      </div>
+      <header>
+        <h1 data-i18n="heroTitle"></h1>
+        <p class="lead" data-i18n="heroLead"></p>
+      </header>
 
-      function drawRoundedRect(context, x, y, width, height, radius) {
-        const r = Math.min(radius, width / 2, height / 2);
-        context.beginPath();
-        context.moveTo(x + r, y);
-        context.lineTo(x + width - r, y);
-        context.quadraticCurveTo(x + width, y, x + width, y + r);
-        context.lineTo(x + width, y + height - r);
-        context.quadraticCurveTo(x + width, y + height, x + width - r, y + height);
-        context.lineTo(x + r, y + height);
-        context.quadraticCurveTo(x, y + height, x, y + height - r);
-        context.lineTo(x, y + r);
-        context.quadraticCurveTo(x, y, x + r, y);
-        context.closePath();
-        context.fill();
+      <section class="idea-grid" aria-label="Available ideas" data-card-grid></section>
+
+      <aside class="cta-note">
+        <strong data-i18n="addNoteTitle"></strong>
+        <p data-i18n="addNoteBody"></p>
+      </aside>
+    </main>
+
+    <noscript>
+      <style>
+        [data-card-grid]::before {
+          content: "Please enable JavaScript to see the Idea Hub cards.";
+          display: block;
+          padding: 24px;
+          border-radius: 18px;
+          background: rgba(15, 23, 42, 0.72);
+          border: 1px solid rgba(148, 163, 184, 0.26);
+        }
+      </style>
+    </noscript>
+
+    <script>
+      const LOCALE_STORAGE_KEY = 'ideaHubLocale';
+      const DEFAULT_LOCALE = 'en';
+      const SUPPORTED_LOCALES = ['en', 'zh-HK'];
+
+      const translations = {
+        en: {
+          pageTitle: 'Idea Hub',
+          heroTitle: 'Idea Hub',
+          heroLead:
+            'Collect and grow your creative experiments here. Drop in a new card each time inspiration strikes, and link out to deep-dive pages that can evolve over time.',
+          addNoteTitle: 'Add a new idea:',
+          addNoteBody:
+            'Duplicate a card entry inside the script below, update the copy, and point the link to a fresh page. The grid expands automatically so you can keep stacking experiments without touching the layout.',
+          toggleAria: 'Switch to Traditional Chinese',
+          cards: {
+            aiStars: {
+              title: 'Top LLM & AI GitHub Stars (Weekly)',
+              description:
+                'Discover the hottest open-source LLM and AI projects on GitHub this week. The list refreshes automatically with the latest GitHub data so you can jump to fast-moving repos while the buzz is fresh.',
+              meta: [
+                { label: 'Focus:', value: 'LLM, Agents, Infrastructure' },
+                { label: 'Updated:', value: 'Rolling 7-day snapshot (auto)' },
+              ],
+            },
+          },
+        },
+        'zh-HK': {
+          pageTitle: '創意樞紐',
+          heroTitle: '創意樞紐',
+          heroLead:
+            '將靈感與實驗收集在這裡。每次有新主意就加入一張卡片，連結到可以持續延伸的詳細頁面，方便日後再擴展。',
+          addNoteTitle: '新增點子：',
+          addNoteBody:
+            '在下方腳本複製一個卡片設定，更新文字與連結到新頁面。版面會自動延伸，方便你不斷加入更多實驗。',
+          toggleAria: '切換至英文',
+          cards: {
+            aiStars: {
+              title: '每週 LLM 與 AI GitHub 星標排行榜',
+              description:
+                '每週精選最火熱的 LLM 與 AI 開源項目。清單會自動更新 GitHub 最新資料，助你即時追蹤熱門儲存庫，趁熱參與。',
+              meta: [
+                { label: '焦點：', value: 'LLM、智能代理、基礎設施' },
+                { label: '更新頻率：', value: '自動滾動 7 日快照' },
+              ],
+            },
+          },
+        },
+      };
+
+      const cards = [
+        {
+          id: 'aiStars',
+          href: 'top-ai-llm-stars.html',
+          icon: '🌟',
+        },
+      ];
+
+      const langToggle = document.querySelector('[data-lang-toggle]');
+      const cardGrid = document.querySelector('[data-card-grid]');
+
+      function getStoredLocale() {
+        const stored = localStorage.getItem(LOCALE_STORAGE_KEY);
+        return SUPPORTED_LOCALES.includes(stored) ? stored : DEFAULT_LOCALE;
       }
 
-      function render() {
-        ctx.fillStyle = '#0b1220';
-        ctx.fillRect(0, 0, canvas.width, canvas.height);
+      function persistLocale(locale) {
+        localStorage.setItem(LOCALE_STORAGE_KEY, locale);
+      }
 
-        ctx.strokeStyle = 'rgba(51, 65, 85, 0.35)';
-        ctx.lineWidth = 1;
-        for (let i = 1; i < tiles; i += 1) {
-          ctx.beginPath();
-          ctx.moveTo(i * tileSize + 0.5, 0);
-          ctx.lineTo(i * tileSize + 0.5, canvas.height);
-          ctx.stroke();
-          ctx.beginPath();
-          ctx.moveTo(0, i * tileSize + 0.5);
-          ctx.lineTo(canvas.width, i * tileSize + 0.5);
-          ctx.stroke();
-        }
+      function applyLocaleToDocument(locale) {
+        document.documentElement.lang = locale === 'zh-HK' ? 'zh-Hant-HK' : 'en';
+      }
 
-        ctx.fillStyle = 'rgba(34, 197, 94, 0.18)';
-        ctx.shadowColor = 'rgba(34, 197, 94, 0.35)';
-        ctx.shadowBlur = 12;
-        drawRoundedRect(ctx, food.x * tileSize + 4, food.y * tileSize + 4, tileSize - 8, tileSize - 8, 6);
-        ctx.shadowBlur = 0;
-
-        snake.forEach((segment, index) => {
-          ctx.fillStyle = index === 0 ? 'var(--snake-head)' : 'var(--snake)';
-          drawRoundedRect(ctx, segment.x * tileSize + 2, segment.y * tileSize + 2, tileSize - 4, tileSize - 4, 6);
+      function updateToggleVisual(locale) {
+        if (!langToggle) return;
+        langToggle.setAttribute('aria-label', translations[locale].toggleAria);
+        langToggle.querySelectorAll('span').forEach((span) => {
+          const spanLocale = span.dataset.langCode;
+          span.dataset.active = spanLocale === locale;
         });
       }
 
-      function queueDirection(direction) {
-        const directionMap = {
-          up: { x: 0, y: -1 },
-          down: { x: 0, y: 1 },
-          left: { x: -1, y: 0 },
-          right: { x: 1, y: 0 }
-        };
-        const desired = directionMap[direction];
-        if (!desired) {
-          return;
-        }
+      function renderCards(locale) {
+        if (!cardGrid) return;
+        cardGrid.innerHTML = '';
+        cards.forEach((card) => {
+          const copy = translations[locale].cards[card.id];
+          if (!copy) return;
 
-        const isMoving = velocity.x !== 0 || velocity.y !== 0;
-        const isOpposite = desired.x === -velocity.x && desired.y === -velocity.y;
-        if (isMoving && isOpposite) {
-          return;
-        }
+          const link = document.createElement('a');
+          link.className = 'idea-card';
+          link.href = card.href;
 
-        nextVelocity = { ...desired };
+          const header = document.createElement('div');
+          header.className = 'card-header';
 
-        if (!gameInterval) {
-          startGame({ ...desired });
-        }
+          const icon = document.createElement('span');
+          icon.className = 'idea-icon';
+          icon.setAttribute('aria-hidden', 'true');
+          icon.textContent = card.icon;
+
+          const title = document.createElement('h2');
+          title.textContent = copy.title;
+
+          header.append(icon, title);
+
+          const description = document.createElement('p');
+          description.textContent = copy.description;
+
+          const metaList = document.createElement('ul');
+          metaList.className = 'meta';
+          copy.meta.forEach((metaItem) => {
+            const li = document.createElement('li');
+            const label = document.createElement('span');
+            label.textContent = metaItem.label;
+            li.append(label, document.createTextNode(metaItem.value));
+            metaList.appendChild(li);
+          });
+
+          link.append(header, description, metaList);
+          cardGrid.appendChild(link);
+        });
       }
 
-      function handleKeydown(event) {
-        const key = event.key.toLowerCase();
-        if (["arrowup", "w"].includes(key)) {
-          event.preventDefault();
-          queueDirection('up');
-        } else if (["arrowdown", "s"].includes(key)) {
-          event.preventDefault();
-          queueDirection('down');
-        } else if (["arrowleft", "a"].includes(key)) {
-          event.preventDefault();
-          queueDirection('left');
-        } else if (["arrowright", "d"].includes(key)) {
-          event.preventDefault();
-          queueDirection('right');
-        } else if (key === ' ') {
-          event.preventDefault();
-          if (!gameInterval) {
-            startGame();
-          }
-        }
+      function renderStaticCopy(locale) {
+        const heroTitle = document.querySelector('[data-i18n="heroTitle"]');
+        const heroLead = document.querySelector('[data-i18n="heroLead"]');
+        const addNoteTitle = document.querySelector('[data-i18n="addNoteTitle"]');
+        const addNoteBody = document.querySelector('[data-i18n="addNoteBody"]');
+
+        document.title = translations[locale].pageTitle;
+        if (heroTitle) heroTitle.textContent = translations[locale].heroTitle;
+        if (heroLead) heroLead.textContent = translations[locale].heroLead;
+        if (addNoteTitle) addNoteTitle.textContent = translations[locale].addNoteTitle;
+        if (addNoteBody) addNoteBody.textContent = translations[locale].addNoteBody;
       }
 
-      function handleControlPress(event) {
-        const direction = event.currentTarget.dataset.direction;
-        queueDirection(direction);
+      function setLocale(locale) {
+        const normalized = SUPPORTED_LOCALES.includes(locale) ? locale : DEFAULT_LOCALE;
+        persistLocale(normalized);
+        applyLocaleToDocument(normalized);
+        updateToggleVisual(normalized);
+        renderStaticCopy(normalized);
+        renderCards(normalized);
       }
 
-      function resetHighScore() {
-        localStorage.removeItem(highScoreKey);
-        highScore = 0;
-        updateScore();
-        statusEl.textContent = '最佳紀錄已清除。';
-      }
+      const initialLocale = getStoredLocale();
+      setLocale(initialLocale);
 
-      startButton.addEventListener('click', startGame);
-      resetButton.addEventListener('click', resetHighScore);
-      window.addEventListener('keydown', handleKeydown);
-      controlButtons.forEach(button => {
-        button.addEventListener('click', handleControlPress);
+      langToggle?.addEventListener('click', () => {
+        const nextLocale = localStorage.getItem(LOCALE_STORAGE_KEY) === 'en' ? 'zh-HK' : 'en';
+        setLocale(nextLocale);
       });
-
-      render();
-    })();
-  </script>
-</body>
+    </script>
+  </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -8,11 +8,12 @@
       :root {
         color-scheme: dark;
         --bg-base: #070b16;
-        --bg-panel: rgba(15, 23, 42, 0.82);
+        --bg-panel: rgba(15, 23, 42, 0.84);
         --accent: #38bdf8;
         --accent-strong: #22d3ee;
         --text: #e2e8f0;
-        --text-soft: rgba(226, 232, 240, 0.72);
+        --text-soft: rgba(226, 232, 240, 0.75);
+        --border: rgba(148, 163, 184, 0.25);
         font-family: "Inter", "Segoe UI", "Helvetica Neue", Arial, sans-serif;
       }
 
@@ -26,7 +27,7 @@
         display: flex;
         align-items: center;
         justify-content: center;
-        padding: clamp(20px, 5vw, 48px);
+        padding: clamp(20px, 6vw, 52px);
         background:
           radial-gradient(circle at 12% 18%, rgba(56, 189, 248, 0.22), transparent 60%),
           radial-gradient(circle at 88% 12%, rgba(129, 140, 248, 0.16), transparent 62%),
@@ -35,157 +36,31 @@
       }
 
       main {
-        width: min(960px, 100%);
+        width: min(1020px, 100%);
         background: var(--bg-panel);
         border-radius: 28px;
-        border: 1px solid rgba(148, 163, 184, 0.22);
+        border: 1px solid var(--border);
         box-shadow: 0 28px 60px rgba(2, 6, 23, 0.45);
-        padding: clamp(24px, 4vw, 42px);
-        backdrop-filter: blur(16px);
+        padding: clamp(24px, 5vw, 48px);
+        backdrop-filter: blur(18px);
         position: relative;
-      }
-
-      header {
-        display: flex;
-        flex-direction: column;
-        gap: 12px;
-        margin-bottom: clamp(24px, 5vw, 40px);
-        text-align: center;
-      }
-
-      h1 {
-        margin: 0;
-        font-size: clamp(2rem, 5vw, 2.75rem);
-        font-weight: 700;
-        letter-spacing: 0.01em;
-      }
-
-      .lead {
-        margin: 0 auto;
-        max-width: 580px;
-        font-size: clamp(1rem, 2.6vw, 1.08rem);
-        color: var(--text-soft);
-        line-height: 1.6;
-      }
-
-      .idea-grid {
-        display: grid;
-        gap: clamp(16px, 3vw, 24px);
-        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-      }
-
-      .idea-card {
-        display: flex;
-        flex-direction: column;
-        gap: 12px;
-        padding: clamp(20px, 3vw, 26px);
-        border-radius: 22px;
-        background: rgba(15, 23, 42, 0.72);
-        border: 1px solid rgba(148, 163, 184, 0.26);
-        text-decoration: none;
-        color: inherit;
-        transition: transform 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease;
-      }
-
-      .idea-card:hover,
-      .idea-card:focus-visible {
-        transform: translateY(-4px);
-        border-color: rgba(56, 189, 248, 0.52);
-        box-shadow: 0 18px 32px rgba(8, 47, 73, 0.4);
-        outline: none;
-      }
-
-      .card-header {
-        display: flex;
-        align-items: center;
-        gap: 12px;
-      }
-
-      .idea-icon {
-        flex-shrink: 0;
-        width: 42px;
-        height: 42px;
-        border-radius: 14px;
-        display: grid;
-        place-items: center;
-        font-size: 1.4rem;
-        background: rgba(56, 189, 248, 0.16);
-        border: 1px solid rgba(56, 189, 248, 0.35);
-      }
-
-      .idea-card h2 {
-        margin: 0;
-        font-size: 1.18rem;
-        font-weight: 600;
-      }
-
-      .idea-card p {
-        margin: 0;
-        color: var(--text-soft);
-        line-height: 1.5;
-        font-size: 0.98rem;
-      }
-
-      .meta {
-        margin: 0;
-        padding: 0;
-        list-style: none;
-        display: flex;
-        flex-wrap: wrap;
-        gap: 10px;
-        font-size: 0.78rem;
-        color: rgba(148, 163, 184, 0.8);
-      }
-
-      .meta span {
-        color: var(--accent);
-        font-weight: 600;
-      }
-
-      .meta li {
-        display: flex;
-        gap: 6px;
-        align-items: center;
-        background: rgba(15, 23, 42, 0.72);
-        border-radius: 999px;
-        padding: 6px 12px;
-        border: 1px solid rgba(148, 163, 184, 0.24);
-      }
-
-      .cta-note {
-        margin-top: clamp(24px, 4vw, 32px);
-        padding: clamp(18px, 3vw, 24px);
-        border-radius: 18px;
-        border: 1px dashed rgba(148, 163, 184, 0.35);
-        background: rgba(15, 23, 42, 0.6);
-        font-size: 0.92rem;
-        color: var(--text-soft);
-        line-height: 1.6;
-      }
-
-      .cta-note strong {
-        color: var(--text);
-        display: block;
-        margin-bottom: 6px;
       }
 
       .top-bar {
         position: absolute;
         top: clamp(16px, 3vw, 24px);
         right: clamp(16px, 3vw, 24px);
-        display: flex;
-        justify-content: flex-end;
       }
 
       .lang-toggle {
         display: inline-flex;
         align-items: center;
-        gap: 6px;
-        padding: 8px 14px;
+        gap: 8px;
+        padding: 8px 16px;
         border-radius: 999px;
         border: 1px solid rgba(148, 163, 184, 0.3);
-        background: rgba(15, 23, 42, 0.7);
-        color: var(--text);
+        background: rgba(15, 23, 42, 0.72);
+        color: inherit;
         cursor: pointer;
         font-size: 0.85rem;
         font-weight: 600;
@@ -199,24 +74,177 @@
         outline: none;
       }
 
-      .lang-toggle span {
-        opacity: 0.6;
-        transition: opacity 0.18s ease;
-      }
-
       .lang-toggle span[data-active="true"] {
         opacity: 1;
       }
 
-      @media (max-width: 600px) {
-        .idea-card {
-          padding: 18px;
+      .lang-toggle span[data-lang-code] {
+        opacity: 0.55;
+        transition: opacity 0.18s ease;
+      }
+
+      header {
+        display: flex;
+        flex-direction: column;
+        gap: 14px;
+        margin-bottom: clamp(24px, 5vw, 40px);
+      }
+
+      .eyebrow {
+        margin: 0;
+        text-transform: uppercase;
+        letter-spacing: 0.32em;
+        font-size: 0.76rem;
+        color: var(--accent);
+        font-weight: 600;
+      }
+
+      h1 {
+        margin: 0;
+        font-size: clamp(2.1rem, 5vw, 2.8rem);
+        font-weight: 700;
+        letter-spacing: 0.01em;
+      }
+
+      .lead {
+        margin: 0;
+        max-width: 620px;
+        color: var(--text-soft);
+        font-size: clamp(1rem, 2.8vw, 1.08rem);
+        line-height: 1.6;
+      }
+
+      .idea-grid {
+        display: grid;
+        gap: clamp(18px, 4vw, 26px);
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      }
+
+      .idea-card {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+        padding: clamp(22px, 4vw, 28px);
+        border-radius: 22px;
+        text-decoration: none;
+        background: rgba(15, 23, 42, 0.72);
+        border: 1px solid rgba(148, 163, 184, 0.28);
+        color: inherit;
+        transition: transform 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease;
+      }
+
+      .idea-card:hover,
+      .idea-card:focus-visible {
+        transform: translateY(-4px);
+        border-color: rgba(56, 189, 248, 0.5);
+        box-shadow: 0 18px 34px rgba(8, 47, 73, 0.4);
+        outline: none;
+      }
+
+      .card-header {
+        display: flex;
+        gap: 14px;
+        align-items: flex-start;
+      }
+
+      .idea-icon {
+        flex-shrink: 0;
+        width: 46px;
+        height: 46px;
+        border-radius: 16px;
+        display: grid;
+        place-items: center;
+        font-size: 1.5rem;
+        background: rgba(56, 189, 248, 0.18);
+        border: 1px solid rgba(56, 189, 248, 0.35);
+      }
+
+      .card-text h2 {
+        margin: 0;
+        font-size: 1.16rem;
+        font-weight: 600;
+      }
+
+      .card-text p {
+        margin: 8px 0 0;
+        color: var(--text-soft);
+        font-size: 0.98rem;
+        line-height: 1.55;
+      }
+
+      .meta {
+        margin: 0;
+        padding: 0;
+        list-style: none;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+      }
+
+      .meta li {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 6px 12px;
+        border-radius: 999px;
+        background: rgba(15, 23, 42, 0.62);
+        border: 1px solid rgba(148, 163, 184, 0.24);
+        font-size: 0.78rem;
+        color: rgba(226, 232, 240, 0.82);
+      }
+
+      .meta li span {
+        color: var(--accent);
+        font-weight: 600;
+      }
+
+      .helper {
+        margin-top: clamp(32px, 6vw, 48px);
+        padding: clamp(20px, 4vw, 26px);
+        border-radius: 20px;
+        border: 1px dashed rgba(148, 163, 184, 0.35);
+        background: rgba(15, 23, 42, 0.6);
+      }
+
+      .helper h2 {
+        margin: 0 0 12px;
+        font-size: 1.04rem;
+        font-weight: 600;
+      }
+
+      .helper p {
+        margin: 0 0 16px;
+        color: var(--text-soft);
+        font-size: 0.95rem;
+        line-height: 1.6;
+      }
+
+      .helper ol {
+        margin: 0;
+        padding-left: 22px;
+        color: rgba(226, 232, 240, 0.86);
+        font-size: 0.93rem;
+        line-height: 1.55;
+      }
+
+      .helper ol li + li {
+        margin-top: 8px;
+      }
+
+      @media (max-width: 640px) {
+        body {
+          padding: 16px;
+        }
+
+        main {
+          padding: 20px;
         }
 
         .top-bar {
           position: static;
-          justify-content: center;
-          margin-bottom: 18px;
+          display: flex;
+          justify-content: flex-end;
+          margin-bottom: 16px;
         }
       }
     </style>
@@ -224,96 +252,198 @@
   <body>
     <main>
       <div class="top-bar">
-        <button type="button" class="lang-toggle" data-lang-toggle aria-label="Switch language">
-          <span data-lang-code="en" data-active="true">EN</span> / <span data-lang-code="zh-HK">繁</span>
+        <button type="button" id="langToggle" class="lang-toggle" aria-label="Toggle language">
+          <span data-lang-code="en" data-active="true">EN</span>
+          <span aria-hidden="true">/</span>
+          <span data-lang-code="zh-HK">繁</span>
         </button>
       </div>
       <header>
-        <h1 data-i18n="heroTitle"></h1>
-        <p class="lead" data-i18n="heroLead"></p>
+        <p class="eyebrow" data-i18n="eyebrow">Idea Hub</p>
+        <h1 data-i18n="headline">Choose a concept to explore</h1>
+        <p class="lead" data-i18n="intro">
+          Use these quick links to jump into prototypes, notes, or dashboards. Add new cards whenever inspiration
+          strikes—each tile is generated from the data list below.
+        </p>
       </header>
-
-      <section class="idea-grid" aria-label="Available ideas" data-card-grid></section>
-
-      <aside class="cta-note">
-        <strong data-i18n="addNoteTitle"></strong>
-        <p data-i18n="addNoteBody"></p>
-      </aside>
+      <section class="idea-grid" id="ideaGrid" aria-live="polite"></section>
+      <section class="helper">
+        <h2 data-i18n="howToTitle">Add a new sublink</h2>
+        <p data-i18n="howToIntro">
+          Every card on this page is driven by a single JavaScript array. Editing that list is all you need to keep the
+          hub growing.
+        </p>
+        <ol id="howToList">
+          <li data-step-index="0">Duplicate one of the objects in the <code>ideas</code> array.</li>
+          <li data-step-index="1">Update the <code>href</code>, icon, and localized copy for English and zh-HK.</li>
+          <li data-step-index="2">Save the file—your new tile appears automatically.</li>
+        </ol>
+      </section>
     </main>
-
-    <noscript>
-      <style>
-        [data-card-grid]::before {
-          content: "Please enable JavaScript to see the Idea Hub cards.";
-          display: block;
-          padding: 24px;
-          border-radius: 18px;
-          background: rgba(15, 23, 42, 0.72);
-          border: 1px solid rgba(148, 163, 184, 0.26);
-        }
-      </style>
-    </noscript>
-
     <script>
-      const LOCALE_STORAGE_KEY = 'ideaHubLocale';
-      const DEFAULT_LOCALE = 'en';
       const SUPPORTED_LOCALES = ['en', 'zh-HK'];
+      const DEFAULT_LOCALE = 'en';
+      const LOCALE_STORAGE_KEY = 'ideaHubLocale';
+      const localeFallbacks = {
+        en: 'en',
+        'zh-HK': 'zh-Hant-HK',
+      };
 
       const translations = {
         en: {
-          pageTitle: 'Idea Hub',
-          heroTitle: 'Idea Hub',
-          heroLead:
-            'Collect and grow your creative experiments here. Drop in a new card each time inspiration strikes, and link out to deep-dive pages that can evolve over time.',
-          addNoteTitle: 'Add a new idea:',
-          addNoteBody:
-            'Duplicate a card entry inside the script below, update the copy, and point the link to a fresh page. The grid expands automatically so you can keep stacking experiments without touching the layout.',
-          toggleAria: 'Switch to Traditional Chinese',
-          cards: {
-            aiStars: {
-              title: 'Top LLM & AI GitHub Stars (Weekly)',
-              description:
-                'Discover the hottest open-source LLM and AI projects on GitHub this week. The list refreshes automatically with the latest GitHub data so you can jump to fast-moving repos while the buzz is fresh.',
-              meta: [
-                { label: 'Focus:', value: 'LLM, Agents, Infrastructure' },
-                { label: 'Updated:', value: 'Rolling 7-day snapshot (auto)' },
-              ],
-            },
-          },
+          toggleAria: 'Toggle language between English and Traditional Chinese (Hong Kong)',
+          eyebrow: 'Idea Hub',
+          headline: 'Choose a concept to explore',
+          intro:
+            'Use these quick links to jump into prototypes, notes, or dashboards. Add new cards whenever inspiration strikes—each tile is generated from the data list below.',
+          howToTitle: 'Add a new sublink',
+          howToIntro:
+            'Every card on this page is driven by a single JavaScript array. Editing that list is all you need to keep the hub growing.',
+          howToSteps: [
+            'Duplicate one of the objects in the ideas array.',
+            'Update the link, icon, and localized copy for English and zh-HK.',
+            'Save the file—your new tile appears automatically.',
+          ],
         },
         'zh-HK': {
-          pageTitle: '創意樞紐',
-          heroTitle: '創意樞紐',
-          heroLead:
-            '將靈感與實驗收集在這裡。每次有新主意就加入一張卡片，連結到可以持續延伸的詳細頁面，方便日後再擴展。',
-          addNoteTitle: '新增點子：',
-          addNoteBody:
-            '在下方腳本複製一個卡片設定，更新文字與連結到新頁面。版面會自動延伸，方便你不斷加入更多實驗。',
-          toggleAria: '切換至英文',
-          cards: {
-            aiStars: {
-              title: '每週 LLM 與 AI GitHub 星標排行榜',
-              description:
-                '每週精選最火熱的 LLM 與 AI 開源項目。清單會自動更新 GitHub 最新資料，助你即時追蹤熱門儲存庫，趁熱參與。',
-              meta: [
-                { label: '焦點：', value: 'LLM、智能代理、基礎設施' },
-                { label: '更新頻率：', value: '自動滾動 7 日快照' },
-              ],
-            },
-          },
+          toggleAria: '在英文與繁體中文（香港）之間切換語言',
+          eyebrow: '創意中樞',
+          headline: '揀選你想瀏覽的構想',
+          intro:
+            '用這些捷徑直接打開原型、筆記或儀錶板。只要更新下面的資料清單，就可以隨時為新點子新增卡片。',
+          howToTitle: '新增子連結',
+          howToIntro: '此頁的所有卡片都來自同一個 JavaScript 陣列，更新它就能持續擴充內容。',
+          howToSteps: [
+            '複製 ideas 陣列中的其中一個物件。',
+            '更新連結、圖示，以及英文與繁體中文（香港）的對應文案。',
+            '儲存檔案後，新卡片便會自動出現。',
+          ],
         },
       };
 
-      const cards = [
+      const ideas = [
         {
-          id: 'aiStars',
+          id: 'top-ai-llm-stars',
+          icon: '✨',
           href: 'top-ai-llm-stars.html',
-          icon: '🌟',
+          copy: {
+            en: {
+              title: 'Top LLM & AI GitHub Stars',
+              summary:
+                'Track the five fastest-growing repositories from the past seven days. Data refreshes each visit using the GitHub Search API.',
+            },
+            'zh-HK': {
+              title: 'LLM 與 AI 每週 GitHub 星標前五名',
+              summary: '查看最近七天星標成長最快的五個專案，每次載入都會透過 GitHub 搜尋 API 即時更新。',
+            },
+          },
+          badges: [
+            {
+              id: 'cadence',
+              text: {
+                en: 'Weekly snapshot',
+                'zh-HK': '每週快照',
+              },
+            },
+            {
+              id: 'source',
+              text: {
+                en: 'Live GitHub Search',
+                'zh-HK': '即時 GitHub 搜尋',
+              },
+            },
+          ],
         },
       ];
 
-      const langToggle = document.querySelector('[data-lang-toggle]');
-      const cardGrid = document.querySelector('[data-card-grid]');
+      const ideaGrid = document.getElementById('ideaGrid');
+      const langToggle = document.getElementById('langToggle');
+      const eyebrowEl = document.querySelector('[data-i18n="eyebrow"]');
+      const headlineEl = document.querySelector('[data-i18n="headline"]');
+      const introEl = document.querySelector('[data-i18n="intro"]');
+      const howToTitleEl = document.querySelector('[data-i18n="howToTitle"]');
+      const howToIntroEl = document.querySelector('[data-i18n="howToIntro"]');
+      const howToListEl = document.getElementById('howToList');
+
+      let currentLocale = DEFAULT_LOCALE;
+
+      function createCard(idea, locale) {
+        const link = document.createElement('a');
+        link.className = 'idea-card';
+        link.href = idea.href;
+        link.setAttribute('data-idea-id', idea.id);
+
+        const header = document.createElement('div');
+        header.className = 'card-header';
+
+        const icon = document.createElement('span');
+        icon.className = 'idea-icon';
+        icon.setAttribute('aria-hidden', 'true');
+        icon.textContent = idea.icon;
+
+        const textWrapper = document.createElement('div');
+        textWrapper.className = 'card-text';
+
+        const title = document.createElement('h2');
+        title.textContent = idea.copy[locale].title;
+
+        const summary = document.createElement('p');
+        summary.textContent = idea.copy[locale].summary;
+
+        textWrapper.append(title, summary);
+        header.append(icon, textWrapper);
+        link.append(header);
+
+        if (Array.isArray(idea.badges) && idea.badges.length > 0) {
+          const metaList = document.createElement('ul');
+          metaList.className = 'meta';
+
+          idea.badges.forEach((badge) => {
+            const item = document.createElement('li');
+            item.textContent = badge.text[locale];
+            metaList.appendChild(item);
+          });
+
+          link.append(metaList);
+        }
+
+        return link;
+      }
+
+      function renderCards(locale) {
+        ideaGrid.innerHTML = '';
+        ideas.forEach((idea) => {
+          ideaGrid.appendChild(createCard(idea, locale));
+        });
+      }
+
+      function renderStaticCopy(locale) {
+        const copy = translations[locale] || translations[DEFAULT_LOCALE];
+        eyebrowEl.textContent = copy.eyebrow;
+        headlineEl.textContent = copy.headline;
+        introEl.textContent = copy.intro;
+        howToTitleEl.textContent = copy.howToTitle;
+        howToIntroEl.textContent = copy.howToIntro;
+
+        howToListEl.innerHTML = '';
+        copy.howToSteps.forEach((step, index) => {
+          const li = document.createElement('li');
+          li.textContent = step;
+          li.dataset.stepIndex = String(index);
+          howToListEl.appendChild(li);
+        });
+      }
+
+      function applyLocaleToDocument(locale) {
+        document.documentElement.lang = localeFallbacks[locale] || 'en';
+      }
+
+      function updateToggleVisual(locale) {
+        langToggle?.setAttribute('aria-label', translations[locale].toggleAria);
+        langToggle?.querySelectorAll('[data-lang-code]').forEach((span) => {
+          span.dataset.active = span.dataset.langCode === locale ? 'true' : 'false';
+        });
+      }
 
       function getStoredLocale() {
         const stored = localStorage.getItem(LOCALE_STORAGE_KEY);
@@ -324,88 +454,21 @@
         localStorage.setItem(LOCALE_STORAGE_KEY, locale);
       }
 
-      function applyLocaleToDocument(locale) {
-        document.documentElement.lang = locale === 'zh-HK' ? 'zh-Hant-HK' : 'en';
-      }
-
-      function updateToggleVisual(locale) {
-        if (!langToggle) return;
-        langToggle.setAttribute('aria-label', translations[locale].toggleAria);
-        langToggle.querySelectorAll('span').forEach((span) => {
-          const spanLocale = span.dataset.langCode;
-          span.dataset.active = spanLocale === locale;
-        });
-      }
-
-      function renderCards(locale) {
-        if (!cardGrid) return;
-        cardGrid.innerHTML = '';
-        cards.forEach((card) => {
-          const copy = translations[locale].cards[card.id];
-          if (!copy) return;
-
-          const link = document.createElement('a');
-          link.className = 'idea-card';
-          link.href = card.href;
-
-          const header = document.createElement('div');
-          header.className = 'card-header';
-
-          const icon = document.createElement('span');
-          icon.className = 'idea-icon';
-          icon.setAttribute('aria-hidden', 'true');
-          icon.textContent = card.icon;
-
-          const title = document.createElement('h2');
-          title.textContent = copy.title;
-
-          header.append(icon, title);
-
-          const description = document.createElement('p');
-          description.textContent = copy.description;
-
-          const metaList = document.createElement('ul');
-          metaList.className = 'meta';
-          copy.meta.forEach((metaItem) => {
-            const li = document.createElement('li');
-            const label = document.createElement('span');
-            label.textContent = metaItem.label;
-            li.append(label, document.createTextNode(metaItem.value));
-            metaList.appendChild(li);
-          });
-
-          link.append(header, description, metaList);
-          cardGrid.appendChild(link);
-        });
-      }
-
-      function renderStaticCopy(locale) {
-        const heroTitle = document.querySelector('[data-i18n="heroTitle"]');
-        const heroLead = document.querySelector('[data-i18n="heroLead"]');
-        const addNoteTitle = document.querySelector('[data-i18n="addNoteTitle"]');
-        const addNoteBody = document.querySelector('[data-i18n="addNoteBody"]');
-
-        document.title = translations[locale].pageTitle;
-        if (heroTitle) heroTitle.textContent = translations[locale].heroTitle;
-        if (heroLead) heroLead.textContent = translations[locale].heroLead;
-        if (addNoteTitle) addNoteTitle.textContent = translations[locale].addNoteTitle;
-        if (addNoteBody) addNoteBody.textContent = translations[locale].addNoteBody;
-      }
-
       function setLocale(locale) {
-        const normalized = SUPPORTED_LOCALES.includes(locale) ? locale : DEFAULT_LOCALE;
-        persistLocale(normalized);
-        applyLocaleToDocument(normalized);
-        updateToggleVisual(normalized);
-        renderStaticCopy(normalized);
-        renderCards(normalized);
+        const nextLocale = SUPPORTED_LOCALES.includes(locale) ? locale : DEFAULT_LOCALE;
+        currentLocale = nextLocale;
+        persistLocale(nextLocale);
+        applyLocaleToDocument(nextLocale);
+        updateToggleVisual(nextLocale);
+        renderStaticCopy(nextLocale);
+        renderCards(nextLocale);
       }
 
       const initialLocale = getStoredLocale();
       setLocale(initialLocale);
 
       langToggle?.addEventListener('click', () => {
-        const nextLocale = localStorage.getItem(LOCALE_STORAGE_KEY) === 'en' ? 'zh-HK' : 'en';
+        const nextLocale = currentLocale === 'en' ? 'zh-HK' : 'en';
         setLocale(nextLocale);
       });
     </script>

--- a/top-ai-llm-stars.html
+++ b/top-ai-llm-stars.html
@@ -1,0 +1,692 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Top LLM &amp; AI GitHub Stars (Weekly)</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg-base: #070b16;
+        --bg-panel: rgba(15, 23, 42, 0.86);
+        --accent: #38bdf8;
+        --accent-strong: #22d3ee;
+        --text: #e2e8f0;
+        --text-soft: rgba(226, 232, 240, 0.75);
+        --border: rgba(148, 163, 184, 0.28);
+        font-family: "Inter", "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: clamp(20px, 5vw, 48px);
+        background:
+          radial-gradient(circle at 12% 18%, rgba(56, 189, 248, 0.22), transparent 60%),
+          radial-gradient(circle at 88% 12%, rgba(129, 140, 248, 0.16), transparent 62%),
+          linear-gradient(140deg, #020617 0%, #0f172a 60%, #1e293b 100%);
+        color: var(--text);
+      }
+
+      main {
+        width: min(920px, 100%);
+        background: var(--bg-panel);
+        border-radius: 28px;
+        border: 1px solid var(--border);
+        box-shadow: 0 28px 60px rgba(2, 6, 23, 0.45);
+        padding: clamp(24px, 4vw, 44px);
+        backdrop-filter: blur(18px);
+        position: relative;
+      }
+
+      header {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        margin-bottom: clamp(24px, 4vw, 36px);
+      }
+
+      .top-bar {
+        position: absolute;
+        top: clamp(16px, 3vw, 24px);
+        right: clamp(16px, 3vw, 24px);
+        display: flex;
+        justify-content: flex-end;
+      }
+
+      .lang-toggle {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 8px 14px;
+        border-radius: 999px;
+        border: 1px solid rgba(148, 163, 184, 0.3);
+        background: rgba(15, 23, 42, 0.7);
+        color: var(--text);
+        cursor: pointer;
+        font-size: 0.85rem;
+        font-weight: 600;
+        transition: border-color 0.18s ease, background 0.18s ease, color 0.18s ease;
+      }
+
+      .lang-toggle:hover,
+      .lang-toggle:focus-visible {
+        border-color: rgba(56, 189, 248, 0.6);
+        color: var(--accent-strong);
+        outline: none;
+      }
+
+      .lang-toggle span {
+        opacity: 0.6;
+        transition: opacity 0.18s ease;
+      }
+
+      .lang-toggle span[data-active="true"] {
+        opacity: 1;
+      }
+
+      .breadcrumb {
+        font-size: 0.85rem;
+        color: var(--text-soft);
+        display: inline-flex;
+        gap: 8px;
+        align-items: center;
+      }
+
+      .breadcrumb a {
+        color: var(--accent);
+        text-decoration: none;
+        font-weight: 600;
+      }
+
+      .breadcrumb a:hover {
+        text-decoration: underline;
+      }
+
+      h1 {
+        margin: 0;
+        font-size: clamp(2rem, 4.8vw, 2.6rem);
+        font-weight: 700;
+      }
+
+      .lead {
+        margin: 0;
+        font-size: 1rem;
+        color: var(--text-soft);
+        line-height: 1.6;
+        max-width: 680px;
+      }
+
+      .snapshot-meta {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+        margin: clamp(16px, 3vw, 24px) 0;
+        font-size: 0.86rem;
+        color: rgba(148, 163, 184, 0.85);
+      }
+
+      .snapshot-meta span {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        background: rgba(15, 23, 42, 0.68);
+        border-radius: 999px;
+        padding: 6px 12px;
+        border: 1px solid rgba(148, 163, 184, 0.24);
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        background: rgba(15, 23, 42, 0.7);
+        border-radius: 22px;
+        overflow: hidden;
+        border: 1px solid rgba(148, 163, 184, 0.26);
+      }
+
+      thead {
+        background: rgba(15, 23, 42, 0.9);
+      }
+
+      th,
+      td {
+        padding: clamp(14px, 2.8vw, 18px);
+        text-align: left;
+        border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+      }
+
+      th {
+        font-size: 0.78rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: rgba(148, 163, 184, 0.8);
+      }
+
+      tbody tr:last-child td {
+        border-bottom: none;
+      }
+
+      tbody tr:hover {
+        background: rgba(30, 64, 175, 0.18);
+      }
+
+      .repo {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+      }
+
+      .repo a {
+        color: var(--accent);
+        font-weight: 600;
+        text-decoration: none;
+      }
+
+      .repo a:hover {
+        text-decoration: underline;
+      }
+
+      .tags {
+        display: inline-flex;
+        flex-wrap: wrap;
+        gap: 6px;
+        font-size: 0.75rem;
+        color: rgba(148, 163, 184, 0.85);
+      }
+
+      .tag-chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+        padding: 4px 10px;
+        border-radius: 999px;
+        background: rgba(56, 189, 248, 0.14);
+        border: 1px solid rgba(56, 189, 248, 0.3);
+        color: var(--accent);
+      }
+
+      .loading-state {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 12px;
+        padding: 28px 18px;
+        color: rgba(148, 163, 184, 0.8);
+        font-size: 0.95rem;
+      }
+
+      .loading-state .spinner {
+        width: 16px;
+        height: 16px;
+        border-radius: 50%;
+        border: 2px solid rgba(148, 163, 184, 0.28);
+        border-top-color: var(--accent);
+        animation: spin 1s linear infinite;
+      }
+
+      @keyframes spin {
+        from {
+          transform: rotate(0deg);
+        }
+        to {
+          transform: rotate(360deg);
+        }
+      }
+
+      .footnote {
+        margin-top: clamp(22px, 4vw, 32px);
+        font-size: 0.85rem;
+        color: rgba(148, 163, 184, 0.85);
+        line-height: 1.6;
+      }
+
+      @media (max-width: 720px) {
+        main {
+          padding-top: clamp(60px, 12vw, 72px);
+        }
+
+        table,
+        thead,
+        tbody,
+        th,
+        td,
+        tr {
+          display: block;
+        }
+
+        thead {
+          display: none;
+        }
+
+        tbody tr {
+          border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+          padding: 18px 0;
+        }
+
+        tbody tr:last-child {
+          border-bottom: none;
+        }
+
+        td {
+          border: none;
+          padding: 6px 0;
+        }
+
+        td::before {
+          content: attr(data-label);
+          display: block;
+          font-size: 0.75rem;
+          text-transform: uppercase;
+          color: rgba(148, 163, 184, 0.72);
+          margin-bottom: 4px;
+          letter-spacing: 0.08em;
+        }
+
+        .repo {
+          gap: 4px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <div class="top-bar">
+        <button type="button" class="lang-toggle" data-lang-toggle aria-label="Switch language">
+          <span data-lang-code="en" data-active="true">EN</span> / <span data-lang-code="zh-HK">繁</span>
+        </button>
+      </div>
+      <header>
+        <nav class="breadcrumb" aria-label="Breadcrumb">
+          <a href="index.html" data-i18n="breadcrumbHome">← Back to Idea Hub</a>
+          <span data-i18n="breadcrumbCurrent">Weekly snapshot</span>
+        </nav>
+        <h1 data-i18n="heroTitle">Top LLM &amp; AI GitHub Stars</h1>
+        <p class="lead" data-i18n="heroLead">
+          A curated snapshot of the fastest-growing AI and LLM repositories on GitHub this week. Use it to catch up on
+          what the community is excited about, evaluate emerging tooling, or find inspiration for your own experiments.
+        </p>
+        <div class="snapshot-meta" aria-live="polite">
+          <span data-week-range>Rolling 7-day window</span>
+          <span data-i18n="metaSource">Source: GitHub Search API</span>
+          <span data-last-updated>Last refreshed: —</span>
+        </div>
+      </header>
+
+      <table role="table">
+        <thead>
+          <tr>
+            <th scope="col" data-i18n="thRepository">Repository</th>
+            <th scope="col" data-i18n="thHighlights">Highlights</th>
+            <th scope="col" data-i18n="thStars">Stars (since launch)</th>
+          </tr>
+        </thead>
+        <tbody data-results>
+          <tr>
+            <td colspan="3">
+              <div class="loading-state" role="status">
+                <span class="spinner" aria-hidden="true"></span>
+                <span data-i18n="loading">Fetching live repositories…</span>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p class="footnote" data-i18n="footnote">
+        Data refreshes automatically on page load using the public GitHub Search API with a rolling 7-day window. Star
+        counts reflect each repository's total stars since creation during that window and are recalculated daily. If the
+        API rate limit is reached, try again in a few minutes or supply a personal access token in the query string with
+        <code>?token=&lt;your-token&gt;</code>.
+      </p>
+
+      <noscript>
+        <p class="footnote">Enable JavaScript to load the latest weekly LLM and AI repositories from GitHub.</p>
+      </noscript>
+    </main>
+
+    <script>
+      const LOCALE_STORAGE_KEY = 'ideaHubLocale';
+      const DEFAULT_LOCALE = 'en';
+      const SUPPORTED_LOCALES = ['en', 'zh-HK'];
+
+      const localeFallbacks = {
+        en: 'en',
+        'zh-HK': 'zh-Hant-HK',
+      };
+
+      const translations = {
+        en: {
+          pageTitle: 'Top LLM & AI GitHub Stars (Weekly)',
+          toggleAria: 'Switch to Traditional Chinese',
+          breadcrumbHome: '← Back to Idea Hub',
+          breadcrumbCurrent: 'Weekly snapshot',
+          heroTitle: 'Top LLM & AI GitHub Stars',
+          heroLead:
+            'A curated snapshot of the fastest-growing AI and LLM repositories on GitHub this week. Use it to catch up on what the community is excited about, evaluate emerging tooling, or find inspiration for your own experiments.',
+          metaSource: 'Source: GitHub Search API',
+          metaUpdatedPrefix: 'Last refreshed: ',
+          thRepository: 'Repository',
+          thHighlights: 'Highlights',
+          thStars: 'Stars (since launch)',
+          loading: 'Fetching live repositories…',
+          noResults: 'No repositories matched the filters this week. Check back soon!',
+          genericError: 'Something went wrong. Please try again later.',
+          noDescription: 'No description provided.',
+          footnote:
+            "Data refreshes automatically on page load using the public GitHub Search API with a rolling 7-day window. Star counts reflect each repository's total stars since creation during that window and are recalculated daily. If the API rate limit is reached, try again in a few minutes or supply a personal access token in the query string with <code>?token=&lt;your-token&gt;</code>.",
+        },
+        'zh-HK': {
+          pageTitle: '每週 LLM 與 AI GitHub 星標排行榜',
+          toggleAria: '切換至英文',
+          breadcrumbHome: '← 返回 Idea Hub',
+          breadcrumbCurrent: '每週快照',
+          heroTitle: '每週 LLM 與 AI GitHub 星標排行榜',
+          heroLead:
+            '每週整理 GitHub 上成長最快的 AI 與 LLM 儲存庫，用來追蹤社群焦點、評估新工具，或為你的專案找靈感。',
+          metaSource: '資料來源：GitHub Search API',
+          metaUpdatedPrefix: '最後更新：',
+          thRepository: '儲存庫',
+          thHighlights: '重點',
+          thStars: '星標（累計）',
+          loading: '正在擷取最新儲存庫…',
+          noResults: '本週沒有符合條件的儲存庫，稍後再來看看！',
+          genericError: '載入時發生問題，請稍後再試。',
+          noDescription: '沒有提供描述。',
+          footnote:
+            '重新整理頁面時會透過 GitHub Search API 自動更新，採用滾動 7 日視窗。星標數為儲存庫在該時段的累計總數，每日重新計算。若遇到 API 限制，可稍後再試，或於網址加上 <code>?token=&lt;your-token&gt;</code> 使用個人存取權杖。',
+        },
+      };
+
+      const keywords = ['llm', 'language model', 'agent', 'agents', 'langchain', 'rag', 'vector', 'transformer', 'ai'];
+      const maxRows = 5;
+
+      const langToggle = document.querySelector('[data-lang-toggle]');
+      const resultsBody = document.querySelector('[data-results]');
+      const weekRangeLabel = document.querySelector('[data-week-range]');
+      const lastUpdatedLabel = document.querySelector('[data-last-updated]');
+
+      let currentLocale = DEFAULT_LOCALE;
+      let cachedResults = [];
+      let dataLoaded = false;
+
+      function getStoredLocale() {
+        const stored = localStorage.getItem(LOCALE_STORAGE_KEY);
+        return SUPPORTED_LOCALES.includes(stored) ? stored : DEFAULT_LOCALE;
+      }
+
+      function persistLocale(locale) {
+        localStorage.setItem(LOCALE_STORAGE_KEY, locale);
+      }
+
+      function applyLocaleToDocument(locale) {
+        document.documentElement.lang = localeFallbacks[locale] || 'en';
+      }
+
+      function updateToggleVisual(locale) {
+        langToggle?.setAttribute('aria-label', translations[locale].toggleAria);
+        langToggle?.querySelectorAll('span').forEach((span) => {
+          const spanLocale = span.dataset.langCode;
+          span.dataset.active = spanLocale === locale;
+        });
+      }
+
+      function formatDate(date, options = {}) {
+        return new Intl.DateTimeFormat(localeFallbacks[currentLocale] || 'en', {
+          day: 'numeric',
+          month: 'short',
+          year: 'numeric',
+          ...options,
+        }).format(date);
+      }
+
+      function formatCompact(number) {
+        return new Intl.NumberFormat(localeFallbacks[currentLocale] || 'en', {
+          notation: 'compact',
+          maximumFractionDigits: 1,
+        }).format(number);
+      }
+
+      function formatTag(label) {
+        return label
+          .replace(/[-_]/g, ' ')
+          .replace(/\b\w/g, (match) => match.toUpperCase());
+      }
+
+      function renderStaticCopy() {
+        Object.entries(translations[currentLocale]).forEach(([key, value]) => {
+          const nodeList = document.querySelectorAll(`[data-i18n="${key}"]`);
+          nodeList.forEach((node) => {
+            if (key === 'footnote') {
+              node.innerHTML = value;
+            } else {
+              node.textContent = value;
+            }
+          });
+        });
+      }
+
+      function renderMetaDates() {
+        const now = new Date();
+        const since = new Date(now);
+        since.setDate(since.getDate() - 7);
+
+        if (weekRangeLabel) {
+          const from = formatDate(since, { day: 'numeric', month: 'short' });
+          const to = formatDate(now, { day: 'numeric', month: 'short', year: 'numeric' });
+          weekRangeLabel.textContent = `${from} – ${to}`;
+        }
+
+        if (lastUpdatedLabel) {
+          const formattedNow = formatDate(now, { day: 'numeric', month: 'short', year: 'numeric' });
+          lastUpdatedLabel.textContent = `${translations[currentLocale].metaUpdatedPrefix}${formattedNow}`;
+        }
+      }
+
+      function showLoading() {
+        resultsBody.innerHTML = `
+          <tr>
+            <td colspan="3">
+              <div class="loading-state" role="status">
+                <span class="spinner" aria-hidden="true"></span>
+                <span>${translations[currentLocale].loading}</span>
+              </div>
+            </td>
+          </tr>
+        `;
+      }
+
+      function showError(messageKey) {
+        const message =
+          messageKey === 'noResults'
+            ? translations[currentLocale].noResults
+            : translations[currentLocale].genericError;
+        resultsBody.innerHTML = `
+          <tr>
+            <td colspan="3">
+              <div class="loading-state">
+                <span aria-hidden="true">⚠️</span>
+                <span>${message}</span>
+              </div>
+            </td>
+          </tr>
+        `;
+      }
+
+      function createRow(repo) {
+        const tr = document.createElement('tr');
+
+        const repoCell = document.createElement('td');
+        repoCell.dataset.label = translations[currentLocale].thRepository;
+        repoCell.innerHTML = `
+          <div class="repo">
+            <a href="${repo.html_url}" target="_blank" rel="noopener">${repo.full_name}</a>
+            <div class="tags"></div>
+          </div>
+        `;
+
+        const tagsContainer = repoCell.querySelector('.tags');
+        const tagSet = new Set();
+        const topics = repo.topics || [];
+
+        topics.forEach((topic) => {
+          if (tagSet.size < 3) {
+            tagSet.add(formatTag(topic));
+          }
+        });
+
+        if (tagSet.size === 0) {
+          const fallback = repo.language ? [repo.language] : [];
+          [...fallback, 'AI', 'LLM'].forEach((item) => {
+            if (tagSet.size < 3) {
+              tagSet.add(formatTag(item));
+            }
+          });
+        }
+
+        tagSet.forEach((tag) => {
+          const span = document.createElement('span');
+          span.className = 'tag-chip';
+          span.textContent = tag;
+          tagsContainer.appendChild(span);
+        });
+
+        const highlightsCell = document.createElement('td');
+        highlightsCell.dataset.label = translations[currentLocale].thHighlights;
+        const description = repo.description ? repo.description.trim() : translations[currentLocale].noDescription;
+        highlightsCell.textContent = description;
+
+        const starsCell = document.createElement('td');
+        starsCell.dataset.label = translations[currentLocale].thStars;
+        starsCell.textContent = `+${formatCompact(repo.stargazers_count)}`;
+
+        tr.append(repoCell, highlightsCell, starsCell);
+        return tr;
+      }
+
+      async function fetchQuery(query) {
+        const searchParams = new URLSearchParams({
+          q: query,
+          sort: 'stars',
+          order: 'desc',
+          per_page: '20',
+        });
+
+        const token = new URLSearchParams(window.location.search).get('token');
+        const headers = {
+          Accept: 'application/vnd.github+json',
+        };
+
+        if (token) {
+          headers.Authorization = `Bearer ${token}`;
+        }
+
+        const response = await fetch(`https://api.github.com/search/repositories?${searchParams}`, { headers });
+
+        if (!response.ok) {
+          throw new Error(`GitHub API error (${response.status})`);
+        }
+
+        const payload = await response.json();
+        return payload.items || [];
+      }
+
+      function repoIsRelevant(repo) {
+        const haystack = [repo.name, repo.full_name, repo.description || '', ...(repo.topics || [])]
+          .join(' ')
+          .toLowerCase();
+        return keywords.some((keyword) => haystack.includes(keyword));
+      }
+
+      function renderResults() {
+        if (!cachedResults.length) {
+          if (dataLoaded) {
+            showError('noResults');
+          } else {
+            showLoading();
+          }
+          return;
+        }
+
+        resultsBody.innerHTML = '';
+        cachedResults.forEach((repo) => {
+          resultsBody.appendChild(createRow(repo));
+        });
+      }
+
+      async function loadWeeklyStars() {
+        const now = new Date();
+        const since = new Date(now);
+        since.setDate(since.getDate() - 7);
+
+        const sinceIso = since.toISOString().slice(0, 10);
+
+        const queries = [
+          `created:>=${sinceIso}+stars:>=20+llm+in:name,description,readme`,
+          `created:>=${sinceIso}+stars:>=20+ai+agent+in:name,description,readme`,
+        ];
+
+        const results = new Map();
+
+        for (const query of queries) {
+          try {
+            const repos = await fetchQuery(query);
+            repos.forEach((repo) => {
+              if (!results.has(repo.id)) {
+                results.set(repo.id, repo);
+              }
+            });
+          } catch (error) {
+            console.error(error);
+            dataLoaded = true;
+            showError('genericError');
+            return;
+          }
+        }
+
+        cachedResults = Array.from(results.values())
+          .filter(repoIsRelevant)
+          .sort((a, b) => b.stargazers_count - a.stargazers_count)
+          .slice(0, maxRows);
+
+        dataLoaded = true;
+        renderResults();
+      }
+
+      function setLocale(locale, { rerenderOnly = false } = {}) {
+        currentLocale = SUPPORTED_LOCALES.includes(locale) ? locale : DEFAULT_LOCALE;
+        persistLocale(currentLocale);
+        applyLocaleToDocument(currentLocale);
+        updateToggleVisual(currentLocale);
+        renderStaticCopy();
+        document.title = translations[currentLocale].pageTitle;
+        renderMetaDates();
+        if (rerenderOnly) {
+          renderResults();
+        }
+      }
+
+      async function init() {
+        currentLocale = getStoredLocale();
+        setLocale(currentLocale);
+        showLoading();
+        await loadWeeklyStars();
+        renderMetaDates();
+      }
+
+      langToggle?.addEventListener('click', () => {
+        const nextLocale = currentLocale === 'en' ? 'zh-HK' : 'en';
+        setLocale(nextLocale, { rerenderOnly: true });
+      });
+
+      init();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a reusable EN/繁 language toggle stored across pages
- render the Idea Hub card grid dynamically for easier future additions
- localize the weekly AI GitHub snapshot page, including table UI and metadata

## Testing
- not run (static HTML/JS changes)


------
https://chatgpt.com/codex/tasks/task_e_68d4b9134610832e806a28a365443097